### PR TITLE
Scene bounding volume hierarchy for better culling

### DIFF
--- a/Source/Engine/Components/Transform.h
+++ b/Source/Engine/Components/Transform.h
@@ -21,8 +21,16 @@ namespace Engine
     mutable bool dirty = true; // Marks if the transform has changed and if we need to recompute the model matrix next time GetModelMatrix() is called
     mutable glm::mat4 modelMatrix{ 1.0f };
 
-    // Helper to mark as dirty (yes its a one liner but this future proofs the design more so)
-    void MarkDirty() { dirty = true; }
+    // Global value for if any of the transforms were marked dirty this frame
+    // We better make sure to set this back to false at the end of each frame!
+    inline static bool TransformsDirty = false; // I don't think this is thread safe yet
+
+    // Helper to mark as dirty 
+    void MarkDirty()
+    {
+      dirty = true;
+      TransformsDirty = true;
+    }
 
   public:
 
@@ -36,6 +44,18 @@ namespace Engine
     const glm::vec3& GetPosition() const { return position; }
     const glm::vec3& GetScale() const { return scale; }
     const glm::quat& GetRotation() const { return rotation; }
+    const bool IsDirty() const { return dirty; }
+
+    // Static access for scene systems 
+    static bool AreAnyTransformsDirty()
+    {
+      return TransformsDirty;
+    }
+
+    static void ClearGlobalDirtyFlag()
+    {
+      TransformsDirty = false;
+    }
 
     // Public setters that mark the transform as dirty
 

--- a/Source/Engine/Systems/Renderer/Core/Camera/Frustum.h
+++ b/Source/Engine/Systems/Renderer/Core/Camera/Frustum.h
@@ -21,7 +21,7 @@ namespace Engine
 		static void SetCameraMatrices(const glm::mat4& view, const glm::mat4& proj)
 		{
 			glm::mat4 newVP = proj * view;
-
+			// Psuedo dirty flag to check if we even need to recompute by checking if the matrices memory bounds are equal
 			if (!MatricesEqual(newVP, lastVP))
 			{
 				lastVP = newVP;

--- a/Source/Engine/Systems/Renderer/Vulkan/VulkanIndexDraw.h
+++ b/Source/Engine/Systems/Renderer/Vulkan/VulkanIndexDraw.h
@@ -3,6 +3,7 @@
 #include "Buffers/VulkanInstanceBuffer.h"
 #include "Buffers/VulkanGpuInstanceData.h"
 #include "Engine/Systems/Renderer/Core/Meshes/Mesh.h"
+#include "Engine/Systems/Renderer/Core/Material/MaterialData.h"
 
 namespace Engine
 {
@@ -43,14 +44,27 @@ namespace Engine
 		VulkanBuffer* GetDrawCountBuffer() const { return drawCountBuffer.get(); }
 		VulkanBuffer* GetInstanceMetaBuffer() const { return instanceMetaBuffer.get(); }
 
+		// CPU is easily the best option right now, so much so that GPU isn't worth trying to fix and get working (yet)
 		void SetCulledMode(CullMode mode) { cullMode = mode; }
+
+		// No reason to not use this, fundamental GPU optimization for batch draw calls.
 		void SetUseIndirectDrawing(bool value) { useIndirectDrawing = value; }
+
+		// it's a great performance boost but MAYBE has edge case issues in SceneBVH logic with over culling.
+		// So far seems to work fine actually so I have it enabled in VulkanRenderer::Awake().
+		void SetUseQueriedFrustumSceneBVH(bool value) { useQueriedFrustumSceneBVH = value; }
 
 		uint32_t GetInstanceCount() const { return static_cast<uint32_t>(cpuInstanceData.size()); }
 
 	private:
 
 		inline MeshBufferData& GetOrCreateMeshBuffers(const std::shared_ptr<Mesh>& mesh);
+
+		// Helpers for instance buffer update
+		void GatherCandidatesBVH(Scene& scene, const Frustum& frustum);
+		void GatherCandidatesView(const entt::registry& registry, const Frustum* frustum);
+		void AddInstance(const Transform& transform, const std::shared_ptr<MaterialData>& mat, const Frustum* frustum);
+		void UploadAndBatchInstances(uint32_t frameIndex);
 
 		VkDevice device;
 		VkPhysicalDevice physicalDevice;
@@ -67,6 +81,7 @@ namespace Engine
 
 		CullMode cullMode{ CullMode::NONE };
 
+		std::unordered_map<std::shared_ptr<Mesh>, MeshInstanceRange> rangeMap;
 		std::vector<std::pair<std::shared_ptr<Mesh>, MeshInstanceRange>> instanceBatches;
 
 		// Buffers for visibility culling (compute shader output)
@@ -91,6 +106,7 @@ namespace Engine
 		std::vector<entt::entity> bvhVisibleEntities;
 
 		bool useIndirectDrawing{ false };
+		bool useQueriedFrustumSceneBVH{ false };
 
 	};
 

--- a/Source/Engine/Systems/Renderer/Vulkan/VulkanIndexDraw.h
+++ b/Source/Engine/Systems/Renderer/Vulkan/VulkanIndexDraw.h
@@ -88,6 +88,8 @@ namespace Engine
 		std::vector<std::unique_ptr<VulkanBuffer>> indirectCommandBuffers; // [frameCount]
 		std::vector<std::vector<MeshIndirectDrawBatch>> drawBatchesPerFrame; // [frameCount][meshBatch]
 
+		std::vector<entt::entity> bvhVisibleEntities;
+
 		bool useIndirectDrawing{ false };
 
 	};

--- a/Source/Engine/Systems/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/Source/Engine/Systems/Renderer/Vulkan/VulkanRenderer.cpp
@@ -111,10 +111,11 @@ namespace Engine
 
 		// Configure culled rendering mode
 		// Debug mode CPU culling: 100 FPS 
-		// Release mode CPU culling: 2000+ FPS
+		// Release mode CPU culling: 2500+ FPS
 		// GPU compute shader culling is sadly broken and can't be used yet
 		indexDraw->SetCulledMode(VulkanIndexDraw::CullMode::CPU);
-		indexDraw->SetUseIndirectDrawing(true);
+		indexDraw->SetUseIndirectDrawing(true); // will have a more meaningfull impact once we have mega mesh stuff made
+		indexDraw->SetUseQueriedFrustumSceneBVH(true);
 
 		// Hook the index buffer SSBO into our per-frame descriptor sets
 		descriptorManager->CreateInstanceBufferDescriptorSets(indexDraw->GetInstanceBuffer()->GetPerFrameBuffers());

--- a/Source/Engine/Systems/Scene/Scene.cpp
+++ b/Source/Engine/Systems/Scene/Scene.cpp
@@ -53,7 +53,9 @@ namespace Engine
 		}
 	}
 
-	void Scene::InternalSceneUpdate(double dt)
+	// Stuff we don't need to happen thousands of times a second, or needs to be timed, such as physics scene updates.
+	// It might make sense to have sub scene systems be in a data structure that iterates with update inside of here and init and update etc.
+	void Scene::InternalFixedUpdate(unsigned int tickThisSecond)
 	{
 		// Add new frustum cache components if needed
 		for (auto entity : frustumCacheObserver)
@@ -68,10 +70,15 @@ namespace Engine
 		if (sceneBVH)
 		{
 			sceneBVH->UpdateIfNeeded(frustumCacheObserver);
-			Transform::ClearGlobalDirtyFlag();
+			Transform::ClearGlobalDirtyFlag(); // right now doing this here in internal update before Scene::Update prevents gameplay code from leveraging this flag.
 		}
 
 		frustumCacheObserver.clear();
+	}
+
+	void Scene::InternalSceneUpdate(double dt)
+	{
+
 	}
 
 }

--- a/Source/Engine/Systems/Scene/Scene.cpp
+++ b/Source/Engine/Systems/Scene/Scene.cpp
@@ -27,6 +27,7 @@ namespace Engine
 	// Right now the interal scene base init and update are for caching mesh stuff for the frustum culling.
 	// Sooner or later we will have more code here for full on spacial partioning of the scene, 
 	// which will be essential for physics and AI and rendering/generic updates of active chunks.
+	// We are already doing that now with SceneBVH.
 
 	void Scene::InternalSceneInit()
 	{
@@ -38,6 +39,10 @@ namespace Engine
 		// Auto-remove FrustumCullCache when prerequisites are destroyed
 		registry.on_destroy<Engine::Transform>().connect<&Scene::RemoveFrustumCache>(*this);
 		registry.on_destroy<Engine::Material>().connect<&Scene::RemoveFrustumCache>(*this);
+
+		// Initialize SceneBVH grid
+		sceneBVH = std::make_unique<SceneBVH>(registry);
+		sceneBVH->Init();
 	}
 
 	void Scene::RemoveFrustumCache(entt::registry& registry, entt::entity entity)
@@ -50,7 +55,7 @@ namespace Engine
 
 	void Scene::InternalSceneUpdate(double dt)
 	{
-		// if we need to register any new frustum cull caches
+		// Add new frustum cache components if needed
 		for (auto entity : frustumCacheObserver)
 		{
 			if (!registry.any_of<Engine::FrustumCullCache>(entity))
@@ -59,7 +64,14 @@ namespace Engine
 			}
 		}
 
-		frustumCacheObserver.clear(); // clear it once processed
+		// Let BVH manage itself
+		if (sceneBVH)
+		{
+			sceneBVH->UpdateIfNeeded(frustumCacheObserver);
+			Transform::ClearGlobalDirtyFlag();
+		}
+
+		frustumCacheObserver.clear();
 	}
 
 }

--- a/Source/Engine/Systems/Scene/Scene.h
+++ b/Source/Engine/Systems/Scene/Scene.h
@@ -39,6 +39,8 @@ namespace Engine
 
 		void FixedUpdate(unsigned int tickThisSecond) override {};
 
+		void InternalFixedUpdate(unsigned int tickThisSecond);
+
 		int Exit() override { DestroyAllEntities(); return 0; };
 
 		entt::entity CreateEntity();
@@ -98,10 +100,9 @@ namespace Engine
 		// Internals:
 		entt::observer frustumCacheObserver;
 
-		void RemoveFrustumCache(entt::registry& registry, entt::entity entity);
-
-		// High-performance grid BVH
 		std::unique_ptr<SceneBVH> sceneBVH;
+
+		void RemoveFrustumCache(entt::registry& registry, entt::entity entity);
 
 	};
 

--- a/Source/Engine/Systems/Scene/Scene.h
+++ b/Source/Engine/Systems/Scene/Scene.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Library/EnTT/entt.hpp"
+#include "SubSceneSystems/SceneBVH.h"
 
 namespace Engine
 {
@@ -65,6 +66,8 @@ namespace Engine
 		std::shared_ptr<VulkanRenderer> GetVulkanRenderer() const { return GetSystem<VulkanRenderer>(vulkanRenderer); }
 		std::shared_ptr<OpenGLRenderer> GetOpenGLRenderer() const { return GetSystem<OpenGLRenderer>(openGLRenderer); }
 
+		SceneBVH* GetSceneBVH() const { return sceneBVH.get(); }
+
 	protected:
 
 		std::string name;
@@ -92,10 +95,13 @@ namespace Engine
 		std::weak_ptr<VulkanRenderer> vulkanRenderer;
 		std::weak_ptr<OpenGLRenderer> openGLRenderer;
 
-		void RemoveFrustumCache(entt::registry& registry, entt::entity entity);
-
 		// Internals:
 		entt::observer frustumCacheObserver;
+
+		void RemoveFrustumCache(entt::registry& registry, entt::entity entity);
+
+		// High-performance grid BVH
+		std::unique_ptr<SceneBVH> sceneBVH;
 
 	};
 

--- a/Source/Engine/Systems/Scene/SceneSystem.cpp
+++ b/Source/Engine/Systems/Scene/SceneSystem.cpp
@@ -78,6 +78,7 @@ namespace Engine
 	{
 		if (activeScene)
 		{
+			activeScene->InternalFixedUpdate(tickThisSecond);
 			activeScene->FixedUpdate(tickThisSecond);
 		}
 	}

--- a/Source/Engine/Systems/Scene/SubSceneSystems/SceneBVH.cpp
+++ b/Source/Engine/Systems/Scene/SubSceneSystems/SceneBVH.cpp
@@ -24,44 +24,41 @@ namespace Engine
     registry.on_destroy<Material>().connect<&SceneBVH::RemoveEntity>(*this);
   }
 
+  // Macro to expand a corner and update min/max
+#define EXPAND_CORNER(x, y, z)                                                        \
+{                                                                                     \
+    glm::vec3 corner = glm::vec3(model * glm::vec4(x, y, z, 1.0f));                   \
+    worldMin = glm::min(worldMin, corner);                                            \
+    worldMax = glm::max(worldMax, corner);                                            \
+}
+
   SceneBVH::AABB SceneBVH::CalculateWorldAABB(const std::shared_ptr<Mesh>& mesh, const Transform& transform)
   {
     glm::vec3 min = mesh->meshBufferData->aabbMin;
     glm::vec3 max = mesh->meshBufferData->aabbMax;
     glm::mat4 model = transform.GetModelMatrix();
 
-    glm::vec3 corners[8] = {
-        glm::vec3(model * glm::vec4(min.x, min.y, min.z, 1.0f)),
-        glm::vec3(model * glm::vec4(max.x, min.y, min.z, 1.0f)),
-        glm::vec3(model * glm::vec4(min.x, max.y, min.z, 1.0f)),
-        glm::vec3(model * glm::vec4(max.x, max.y, min.z, 1.0f)),
-        glm::vec3(model * glm::vec4(min.x, min.y, max.z, 1.0f)),
-        glm::vec3(model * glm::vec4(max.x, min.y, max.z, 1.0f)),
-        glm::vec3(model * glm::vec4(min.x, max.y, max.z, 1.0f)),
-        glm::vec3(model * glm::vec4(max.x, max.y, max.z, 1.0f))
-    };
+    // Start with first corner (so we can initialize it first)
+    glm::vec3 worldMin = glm::vec3(model * glm::vec4(min.x, min.y, min.z, 1.0f));
+    glm::vec3 worldMax = worldMin;
 
-    glm::vec3 worldMin = corners[0];
-    glm::vec3 worldMax = corners[0];
-
-    for (int i = 1; i < 8; ++i)
-    {
-      worldMin = glm::min(worldMin, corners[i]);
-      worldMax = glm::max(worldMax, corners[i]);
-    }
+    // Unroll remaining 7 corners
+    EXPAND_CORNER(max.x, min.y, min.z);
+    EXPAND_CORNER(min.x, max.y, min.z);
+    EXPAND_CORNER(max.x, max.y, min.z);
+    EXPAND_CORNER(min.x, min.y, max.z);
+    EXPAND_CORNER(max.x, min.y, max.z);
+    EXPAND_CORNER(min.x, max.y, max.z);
+    EXPAND_CORNER(max.x, max.y, max.z);
 
     return { worldMin, worldMax };
   }
 
+#undef EXPAND_CORNER
+
   void SceneBVH::UpdateIfNeeded(entt::observer& frustumObserver)
   {
-    bool needsUpdate = false;
-
-    for (auto entity : frustumObserver)
-    {
-      needsUpdate = true;
-      break;
-    }
+    bool needsUpdate = frustumObserver.empty();
 
     if (!needsUpdate && Transform::AreAnyTransformsDirty())
     {
@@ -138,36 +135,40 @@ namespace Engine
     }
   }
 
+  // Macro for testing a single corner against a plane, we do this so we don't have to declare an array of corners each time
+#define TEST_CORNER(plane, x, y, z) \
+    (glm::dot(glm::vec3(plane), glm::vec3(x, y, z)) + (plane).w < 0.0f ? 1 : 0)
+
+  // IsAABBVisible fully unrolled version
   bool SceneBVH::IsAABBVisible(const Frustum& frustum, const AABB& aabb) const
   {
-    glm::vec3 corners[8] = {
-        { aabb.min.x, aabb.min.y, aabb.min.z },
-        { aabb.max.x, aabb.min.y, aabb.min.z },
-        { aabb.min.x, aabb.max.y, aabb.min.z },
-        { aabb.max.x, aabb.max.y, aabb.min.z },
-        { aabb.min.x, aabb.min.y, aabb.max.z },
-        { aabb.max.x, aabb.min.y, aabb.max.z },
-        { aabb.min.x, aabb.max.y, aabb.max.z },
-        { aabb.max.x, aabb.max.y, aabb.max.z }
-    };
-
-    for (int i = 0; i < 6; ++i)
+    // Unroll for all 6 planes, we still keep this loop though because the compiler is best at optimizing regular fixed size for loops
+    for (int i = 0; i < 6; i++)
     {
+      const glm::vec4& plane = frustum.planes[i];
       int outside = 0;
-      for (int j = 0; j < 8; ++j)
-      {
-        if (glm::dot(glm::vec3(frustum.planes[i]), corners[j]) + frustum.planes[i].w < 0.0f)
-        {
-          outside++;
-        }
-      }
+
+      // Manually test all 8 corners
+      outside += TEST_CORNER(plane, aabb.min.x, aabb.min.y, aabb.min.z);
+      outside += TEST_CORNER(plane, aabb.max.x, aabb.min.y, aabb.min.z);
+      outside += TEST_CORNER(plane, aabb.min.x, aabb.max.y, aabb.min.z);
+      outside += TEST_CORNER(plane, aabb.max.x, aabb.max.y, aabb.min.z);
+      outside += TEST_CORNER(plane, aabb.min.x, aabb.min.y, aabb.max.z);
+      outside += TEST_CORNER(plane, aabb.max.x, aabb.min.y, aabb.max.z);
+      outside += TEST_CORNER(plane, aabb.min.x, aabb.max.y, aabb.max.z);
+      outside += TEST_CORNER(plane, aabb.max.x, aabb.max.y, aabb.max.z);
+
+      // If all corners are outside of this plane, the box is not visible
       if (outside == 8)
       {
         return false;
       }
     }
 
+    // Otherwise, box intersects or is inside the frustum
     return true;
   }
+
+#undef TEST_CORNER
 
 }

--- a/Source/Engine/Systems/Scene/SubSceneSystems/SceneBVH.cpp
+++ b/Source/Engine/Systems/Scene/SubSceneSystems/SceneBVH.cpp
@@ -1,0 +1,173 @@
+#include "PCH.h"
+#include "SceneBVH.h"
+#include "Engine/Components/Material.h"
+#include "Engine/Systems/Renderer/Core/Meshes/Mesh.h"
+#include "Engine/Components/Transform.h"
+#include "Engine/Systems/Renderer/Core/Camera/Frustum.h"
+
+namespace Engine
+{
+
+  SceneBVH::SceneBVH(entt::registry& registry)
+    : registry(registry)
+  {}
+
+  void SceneBVH::Init()
+  {
+    observer.connect(registry, entt::collector
+      .group<Transform, Material>()
+      .update<Transform>()
+      .update<Material>()
+    );
+
+    registry.on_destroy<Transform>().connect<&SceneBVH::RemoveEntity>(*this);
+    registry.on_destroy<Material>().connect<&SceneBVH::RemoveEntity>(*this);
+  }
+
+  SceneBVH::AABB SceneBVH::CalculateWorldAABB(const std::shared_ptr<Mesh>& mesh, const Transform& transform)
+  {
+    glm::vec3 min = mesh->meshBufferData->aabbMin;
+    glm::vec3 max = mesh->meshBufferData->aabbMax;
+    glm::mat4 model = transform.GetModelMatrix();
+
+    glm::vec3 corners[8] = {
+        glm::vec3(model * glm::vec4(min.x, min.y, min.z, 1.0f)),
+        glm::vec3(model * glm::vec4(max.x, min.y, min.z, 1.0f)),
+        glm::vec3(model * glm::vec4(min.x, max.y, min.z, 1.0f)),
+        glm::vec3(model * glm::vec4(max.x, max.y, min.z, 1.0f)),
+        glm::vec3(model * glm::vec4(min.x, min.y, max.z, 1.0f)),
+        glm::vec3(model * glm::vec4(max.x, min.y, max.z, 1.0f)),
+        glm::vec3(model * glm::vec4(min.x, max.y, max.z, 1.0f)),
+        glm::vec3(model * glm::vec4(max.x, max.y, max.z, 1.0f))
+    };
+
+    glm::vec3 worldMin = corners[0];
+    glm::vec3 worldMax = corners[0];
+
+    for (int i = 1; i < 8; ++i)
+    {
+      worldMin = glm::min(worldMin, corners[i]);
+      worldMax = glm::max(worldMax, corners[i]);
+    }
+
+    return { worldMin, worldMax };
+  }
+
+  void SceneBVH::UpdateIfNeeded(entt::observer& frustumObserver)
+  {
+    bool needsUpdate = false;
+
+    for (auto entity : frustumObserver)
+    {
+      needsUpdate = true;
+      break;
+    }
+
+    if (!needsUpdate && Transform::AreAnyTransformsDirty())
+    {
+      needsUpdate = true;
+    }
+
+    if (needsUpdate)
+    {
+      Update();
+    }
+  }
+
+  void SceneBVH::Update()
+  {
+    auto view = registry.view<Transform, Material>();
+
+    for (auto entity : view)
+    {
+      const auto& transform = view.get<Transform>(entity);
+      const auto& mat = view.get<Material>(entity).data;
+      const auto& mesh = mat->mesh;
+
+      auto it = entityToNodeIndex.find(entity);
+      if (it != entityToNodeIndex.end())
+      {
+        // existing update if dirty
+        if (transform.IsDirty())
+        {
+          nodes[it->second].aabb = CalculateWorldAABB(mesh, transform);
+        }
+      }
+      else
+      {
+        // new insert
+        SceneBVH::AABB aabb = CalculateWorldAABB(mesh, transform);
+        nodes.emplace_back(entity, aabb);
+        entityToNodeIndex[entity] = nodes.size() - 1;
+      }
+    }
+
+    observer.clear();
+  }
+
+  void SceneBVH::QueryFrustum(const Frustum& frustum, std::vector<entt::entity>& outVisible) const
+  {
+    outVisible.clear();
+    outVisible.reserve(nodes.size());
+
+    for (const auto& node : nodes)
+    {
+      if (IsAABBVisible(frustum, node.aabb))
+      {
+        outVisible.push_back(node.entity);
+      }
+    }
+  }
+
+  void SceneBVH::RemoveEntity(entt::entity entity)
+  {
+    auto it = entityToNodeIndex.find(entity);
+    if (it != entityToNodeIndex.end())
+    {
+      size_t index = it->second;
+      size_t last = nodes.size() - 1;
+
+      if (index != last)
+      {
+        std::swap(nodes[index], nodes[last]);
+        entityToNodeIndex[nodes[index].entity] = index;
+      }
+
+      nodes.pop_back();
+      entityToNodeIndex.erase(it);
+    }
+  }
+
+  bool SceneBVH::IsAABBVisible(const Frustum& frustum, const AABB& aabb) const
+  {
+    glm::vec3 corners[8] = {
+        { aabb.min.x, aabb.min.y, aabb.min.z },
+        { aabb.max.x, aabb.min.y, aabb.min.z },
+        { aabb.min.x, aabb.max.y, aabb.min.z },
+        { aabb.max.x, aabb.max.y, aabb.min.z },
+        { aabb.min.x, aabb.min.y, aabb.max.z },
+        { aabb.max.x, aabb.min.y, aabb.max.z },
+        { aabb.min.x, aabb.max.y, aabb.max.z },
+        { aabb.max.x, aabb.max.y, aabb.max.z }
+    };
+
+    for (int i = 0; i < 6; ++i)
+    {
+      int outside = 0;
+      for (int j = 0; j < 8; ++j)
+      {
+        if (glm::dot(glm::vec3(frustum.planes[i]), corners[j]) + frustum.planes[i].w < 0.0f)
+        {
+          outside++;
+        }
+      }
+      if (outside == 8)
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+}

--- a/Source/Engine/Systems/Scene/SubSceneSystems/SceneBVH.h
+++ b/Source/Engine/Systems/Scene/SubSceneSystems/SceneBVH.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "Library/glm/glm.hpp"
+#include "Library/EnTT/entt.hpp"
+
+namespace Engine
+{
+
+  class Transform;
+  class Mesh;
+  struct Frustum;
+
+  class SceneBVH
+  {
+
+  public:
+
+    struct AABB
+    {
+      glm::vec3 min;
+      glm::vec3 max;
+    };
+
+    SceneBVH(entt::registry& registry);
+
+    void Init();
+    void Update();
+    void UpdateIfNeeded(entt::observer& frustumObserver);
+    void QueryFrustum(const Frustum& frustum, std::vector<entt::entity>& outVisible) const;
+    void RemoveEntity(entt::entity entity);
+
+  private:
+
+    struct BVHNode
+    {
+      entt::entity entity;
+      AABB aabb;
+
+      BVHNode(entt::entity e, const AABB& box)
+        : entity(e), aabb(box)
+      {}
+    };
+
+    entt::registry& registry;
+    entt::observer observer;
+
+    std::vector<BVHNode> nodes;
+    std::unordered_map<entt::entity, size_t> entityToNodeIndex;
+
+    bool IsAABBVisible(const Frustum& frustum, const AABB& aabb) const;
+    SceneBVH::AABB CalculateWorldAABB(const std::shared_ptr<Mesh>& mesh, const Transform& transform);
+
+  };
+
+}

--- a/Source/Engine/Systems/Scene/SubSceneSystems/SceneBVH.h
+++ b/Source/Engine/Systems/Scene/SubSceneSystems/SceneBVH.h
@@ -6,6 +6,7 @@
 namespace Engine
 {
 
+  // forward declares
   class Transform;
   class Mesh;
   struct Frustum;

--- a/Source/Game/Scenes/Sandbox.cpp
+++ b/Source/Game/Scenes/Sandbox.cpp
@@ -11,7 +11,7 @@ namespace Game
 {
 
 	constexpr static bool doStressTest = true; 
-	constexpr static bool fullyUniqueCubeMeshes = true; // can take the Vulkan renderer to a crawl if we aren't running any culling
+	constexpr static bool fullyUniqueCubeMeshes = false; // can take the Vulkan renderer to a crawl if we aren't running any culling
 	constexpr static bool randomizeCubeRotations = true;
 	// TODO: make more than just cube meshes (pyramids and spheres)
 

--- a/Source/Game/Scenes/Sandbox.cpp
+++ b/Source/Game/Scenes/Sandbox.cpp
@@ -13,7 +13,7 @@ namespace Game
 	constexpr static bool doStressTest = true; 
 	constexpr static bool fullyUniqueCubeMeshes = false; // can take the Vulkan renderer to a crawl if we aren't running any culling
 	constexpr static bool randomizeCubeRotations = true;
-	// TODO: make more than just cube meshes (pyramids and spheres)
+	// TODO: make more than just different colored cube meshes (pyramids and spheres)
 
 	constexpr static const int GRID_HALF_SIZE = 10; // for example 10 makes a 20x20x20 cube of cubes
 	constexpr static const float SPACING = 2.5f;

--- a/Source/Shaders/Vulkan/VertexShaders/vertex_instanced.hlsl
+++ b/Source/Shaders/Vulkan/VertexShaders/vertex_instanced.hlsl
@@ -8,16 +8,16 @@ cbuffer CameraUBO : register(b0, space0)
 
 struct GpuInstanceData
 {
-  float4x4 model;        // 64
+  float4x4 model;
 
-  float4   aabbMin;      // 16
-  float4   aabbMax;      // 16
+  float4 aabbMin;
+  float4 aabbMax;
 
-  uint     textureIndex; // 4
-  float    hasTexture;   // 4
-  uint     meshIndex;    // 4
-  uint     pad;          // 4
-};                       // = 128
+  uint textureIndex;
+  float hasTexture;
+  uint meshInfoIndex;
+  uint materialIndex;
+};
 
 [[vk::binding(1, 0)]]
 StructuredBuffer<GpuInstanceData> instanceBuffer : register(t1, space0);

--- a/Swim Engine.vcxproj
+++ b/Swim Engine.vcxproj
@@ -234,6 +234,7 @@ xcopy "$(ProjectDir)Source\Shaders\OpenGL" "$(TargetDir)Shaders\OpenGL" /E /I /Y
     <ClCompile Include="Source\Engine\Systems\Renderer\Vulkan\VulkanSyncManager.cpp" />
     <ClCompile Include="Source\Engine\Systems\Scene\Scene.cpp" />
     <ClCompile Include="Source\Engine\Systems\Scene\SceneSystem.cpp" />
+    <ClCompile Include="Source\Engine\Systems\Scene\SubSceneSystems\SceneBVH.cpp" />
     <ClCompile Include="Source\Engine\Systems\SystemManager.cpp" />
     <ClCompile Include="Source\Engine\Utility\PCH.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -280,6 +281,7 @@ xcopy "$(ProjectDir)Source\Shaders\OpenGL" "$(TargetDir)Shaders\OpenGL" /E /I /Y
     <ClInclude Include="Source\Engine\Systems\Renderer\Vulkan\VulkanSyncManager.h" />
     <ClInclude Include="Source\Engine\Systems\Scene\Scene.h" />
     <ClInclude Include="Source\Engine\Systems\Scene\SceneSystem.h" />
+    <ClInclude Include="Source\Engine\Systems\Scene\SubSceneSystems\SceneBVH.h" />
     <ClInclude Include="Source\Engine\Systems\SystemManager.h" />
     <ClInclude Include="Source\Engine\Utility\ColorConstants.h" />
     <ClInclude Include="Source\Engine\Utility\PCH.h" />


### PR DESCRIPTION
Scene now has a BVH sub system it updates internally for spacial partitioning, currently being used in draw indexed culling. The draw indexed class was getting really hard to read so that got refactored to be much more readable and scalable based on the flags enabled for cull mode and other features. 