### PR TITLE
Mega Mesh Buffer (Scene done in a single draw call)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Imgui Integration
 2D UI layer that has screen space transforms (always rendered on the angeled plane the camera faces)
 
 # SUPER TODO ONCE MAIN TODO IS DONE
-<br>
 PBR 
 <br>
 Refactor to Clustered Forward+ for global illumination

--- a/README.md
+++ b/README.md
@@ -3,37 +3,34 @@ Using EnTT, my own Scene System and engine + windows messaging framework, and Vu
 <br>
 # TODO
 
-obj/glb loading 
+obj/glb loading + mesh optimizer
 <br>
-meshlets / mega mesh (make the whole renderer as gpu driven to cut down draw calls)
+Scene editor
 <br>
-set up the sandbox to do entity creation and spawning en mass to performance profile, then hook it up to PhysX or Jolt
+Cubemaps for sky box
 <br>
-behavior components with EnTT called in line with the scene system 
+Behavior components with EnTT called in line with the scene system 
 <br>
-probably get imgui set up at some point
+Hook up PhysX/Jolt
+<br>
+Compute culling
+<br>
+Imgui Integration
 <br>
 2D UI layer that has screen space transforms (always rendered on the angeled plane the camera faces)
 
 # SUPER TODO ONCE MAIN TODO IS DONE
-Ray tracer 
 <br>
-Baked lighting
+PBR 
 <br>
-Dynamic environment ligthing
+Refactor to Clustered Forward+ for global illumination
 <br>
 Shadows (baked and dynamic)
 <br>
 GPU driven particle system
 <br>
-PBR and normal maps 
-<br>
-high quality model meshes 
-<br>
-sky sphere/sky box environment tricks to make stuff look not chopped
-<br>
 Skeletal animation system and rag dolls/boned physics bound meshes
 <br>
-Multi thread certain aspects when needed? 
+MiniAudio integration
 <br>
-Make one single beatiful scene with some cool per object and full screen shader effects with physics bound scripted objects
+Thread workers for FileIO and async Scene loading

--- a/Source/Engine/Systems/Renderer/Core/Meshes/MeshBufferData.h
+++ b/Source/Engine/Systems/Renderer/Core/Meshes/MeshBufferData.h
@@ -25,6 +25,10 @@ namespace Engine
 		// Count of indices for rendering
 		uint32_t indexCount = 0;
 
+		// The offsets to use in the mega mesh buffer on the gpu
+		VkDeviceSize vertexOffsetInMegaBuffer = 0;
+		VkDeviceSize indexOffsetInMegaBuffer = 0;
+
 		// ID of the mesh used in the GPU
 		uint32_t meshID = UINT32_MAX;
 

--- a/Source/Engine/Systems/Renderer/Core/Meshes/MeshBufferData.h
+++ b/Source/Engine/Systems/Renderer/Core/Meshes/MeshBufferData.h
@@ -26,6 +26,7 @@ namespace Engine
 		uint32_t indexCount = 0;
 
 		// The offsets to use in the mega mesh buffer on the gpu
+		// These are set in VulkanIndexDraw::UploadMeshToMegaBuffer()
 		VkDeviceSize vertexOffsetInMegaBuffer = 0;
 		VkDeviceSize indexOffsetInMegaBuffer = 0;
 

--- a/Source/Engine/Systems/Renderer/Core/Meshes/MeshPool.cpp
+++ b/Source/Engine/Systems/Renderer/Core/Meshes/MeshPool.cpp
@@ -48,6 +48,11 @@ namespace Engine
 			}
 
 			mesh->meshBufferData->GenerateBuffers(vertices, indices, cachedDevice, cachedPhysicalDevice);
+			SwimEngine::GetInstance()->GetVulkanRenderer()->GetIndexDraw()->UploadMeshToMegaBuffer(
+				vertices,
+				indices,
+				*mesh->meshBufferData
+			);
 		}
 		else if constexpr (SwimEngine::CONTEXT == SwimEngine::RenderContext::OpenGL)
 		{

--- a/Source/Engine/Systems/Renderer/Vulkan/VulkanDescriptorManager.h
+++ b/Source/Engine/Systems/Renderer/Vulkan/VulkanDescriptorManager.h
@@ -20,7 +20,6 @@ namespace Engine
 
 		void CreateLayout();
 		void CreatePool();
-		void CreateComputePool();
 
 		// Create per-frame UBOs and descriptor sets
 		void CreatePerFrameUBOs(VkPhysicalDevice physicalDevice, uint32_t frameCount);
@@ -40,23 +39,11 @@ namespace Engine
 		void UpdateBindlessTexture(uint32_t index, VkImageView imageView, VkSampler sampler) const;
 		void SetBindlessSampler(VkSampler sampler) const;
 
-		void CreateFrustumCullComputeDescriptorSet(
-			VulkanBuffer& uboBuffer,
-			VulkanBuffer& instanceMetaBuffer,      
-			VulkanBuffer& instanceBuffer,
-			VulkanBuffer& visibleModelBuffer,
-			VulkanBuffer& visibleDataBuffer,
-			VulkanBuffer& drawCountBuffer
-		);
-
 		VkDescriptorSetLayout GetLayout() const { return descriptorSetLayout; }
 		VkDescriptorPool GetPool() const { return descriptorPool; }
 
 		VkDescriptorSet GetBindlessSet() const { return bindlessDescriptorSet; }
 		VkDescriptorSetLayout GetBindlessLayout() const { return bindlessSetLayout; }
-
-		VkDescriptorSetLayout GetComputeSetLayout() const { return computeSetLayout; }
-		VkDescriptorSet GetComputeDescriptorSet() const { return computeDescriptorSet; }
 
 		VulkanBuffer* GetPerFrameUBO(uint32_t frameIndex) const
 		{
@@ -96,13 +83,6 @@ namespace Engine
 
 		// Per-frame instance SSBOs
 		std::vector<std::unique_ptr<VulkanBuffer>> perFrameInstanceBuffers;
-
-		// Compute shader layout and set
-		VkDescriptorSetLayout computeSetLayout = VK_NULL_HANDLE;
-		VkDescriptorSet computeDescriptorSet = VK_NULL_HANDLE;
-
-		// Dedicated pool for compute descriptors (storage buffers & UBOs)
-		VkDescriptorPool computeDescriptorPool = VK_NULL_HANDLE;
 
 	};
 

--- a/Source/Engine/Systems/Renderer/Vulkan/VulkanIndexDraw.h
+++ b/Source/Engine/Systems/Renderer/Vulkan/VulkanIndexDraw.h
@@ -17,32 +17,19 @@ namespace Engine
 		 CPU: Solid balanced stratedgy and a geniunely good solution for complex scenes with thousands of unique meshes.
 		 GPU: Best solution on paper but our implementation is super broken and glitchy for more reasons than one.
 		*/
-		enum CullMode { NONE, CPU, GPU };
+		enum CullMode { NONE, CPU, GPU }; // GPU is not implemented 
 
 		VulkanIndexDraw(VkDevice device, VkPhysicalDevice physicalDevice, const int MAX_EXPECTED_INSTANCES, const int MAX_FRAMES_IN_FLIGHT);
 
 		void CreateIndirectBuffers(uint32_t maxDrawCalls, uint32_t framesInFlight);
 
-		void CreateCullOutputBuffers(uint32_t maxInstances);
-
 		void UpdateInstanceBuffer(uint32_t frameIndex);
 
 		void DrawIndexed(uint32_t frameIndex, VkCommandBuffer cmd);
 
-		void DrawCulledIndexed(uint32_t frameIndex, VkCommandBuffer cmd); 
-
-		void ReadbackCulledInstanceData();
-
-		void ZeroDrawCount();
-
 		void CleanUp();
 
 		const std::unique_ptr<VulkanInstanceBuffer>& GetInstanceBuffer() const { return instanceBuffer; }
-
-		VulkanBuffer* GetVisibleModelBuffer() const { return visibleModelBuffer.get(); }
-		VulkanBuffer* GetVisibleDataBuffer() const { return visibleDataBuffer.get(); }
-		VulkanBuffer* GetDrawCountBuffer() const { return drawCountBuffer.get(); }
-		VulkanBuffer* GetInstanceMetaBuffer() const { return instanceMetaBuffer.get(); }
 
 		// CPU is easily the best option right now, so much so that GPU isn't worth trying to fix and get working (yet)
 		void SetCulledMode(CullMode mode) { cullMode = mode; }
@@ -85,12 +72,6 @@ namespace Engine
 
 		std::unordered_map<std::shared_ptr<Mesh>, MeshInstanceRange> rangeMap;
 		std::vector<std::pair<std::shared_ptr<Mesh>, MeshInstanceRange>> instanceBatches;
-
-		// Buffers for visibility culling (compute shader output)
-		std::unique_ptr<VulkanBuffer> visibleModelBuffer;
-		std::unique_ptr<VulkanBuffer> visibleDataBuffer;
-		std::unique_ptr<VulkanBuffer> drawCountBuffer;
-		std::unique_ptr<VulkanBuffer> instanceMetaBuffer;
 
 		std::vector<glm::uvec4> culledVisibleData; // GPU visible output buffer read into CPU
 		uint32_t instanceCountCulled = 0;          // Count of instances that passed culling

--- a/Source/Engine/Systems/Renderer/Vulkan/VulkanIndexDraw.h
+++ b/Source/Engine/Systems/Renderer/Vulkan/VulkanIndexDraw.h
@@ -23,6 +23,10 @@ namespace Engine
 
 		void CreateIndirectBuffers(uint32_t maxDrawCalls, uint32_t framesInFlight);
 
+		void CreateMegaMeshBuffers(VkDeviceSize totalVertexBufferSize, VkDeviceSize totalIndexBufferSize);
+
+		void UploadMeshToMegaBuffer(const std::vector<Vertex>& vertices, const std::vector<uint16_t>& indices, MeshBufferData& meshData);
+
 		void UpdateInstanceBuffer(uint32_t frameIndex);
 
 		void DrawIndexed(uint32_t frameIndex, VkCommandBuffer cmd);
@@ -52,6 +56,10 @@ namespace Engine
 		void GatherCandidatesView(const entt::registry& registry, const Frustum* frustum);
 		void AddInstance(const Transform& transform, const std::shared_ptr<MaterialData>& mat, const Frustum* frustum);
 		void UploadAndBatchInstances(uint32_t frameIndex);
+
+		void GrowMegaBuffers(VkDeviceSize additionalVertexSize, VkDeviceSize additionalIndexSize);
+
+		bool HasSpaceForMesh(VkDeviceSize vertexSize, VkDeviceSize indexSize) const;
 
 		void DebugWireframeDraw();
 
@@ -85,6 +93,21 @@ namespace Engine
 
 		std::vector<std::unique_ptr<VulkanBuffer>> indirectCommandBuffers; // [frameCount]
 		std::vector<std::vector<MeshIndirectDrawBatch>> drawBatchesPerFrame; // [frameCount][meshBatch]
+
+		// Mega mesh buffers
+		std::unique_ptr<VulkanBuffer> megaVertexBuffer;
+		std::unique_ptr<VulkanBuffer> megaIndexBuffer;
+
+		// Track how large the mega buffers are 
+		VkDeviceSize megaVertexBufferSize = 0;
+		VkDeviceSize megaIndexBufferSize = 0;
+
+		// Tracking offsets
+		VkDeviceSize currentVertexBufferOffset = 0;
+		VkDeviceSize currentIndexBufferOffset = 0;
+
+		// How big to grow each time we run out
+		static constexpr VkDeviceSize MESH_BUFFER_GROWTH_SIZE = 8 * 1024 * 1024; // 8 MB blocks
 
 		bool useIndirectDrawing{ false };
 		bool useQueriedFrustumSceneBVH{ false };

--- a/Source/Engine/Systems/Renderer/Vulkan/VulkanPipelineManager.cpp
+++ b/Source/Engine/Systems/Renderer/Vulkan/VulkanPipelineManager.cpp
@@ -35,18 +35,6 @@ namespace Engine
 			vkDestroyRenderPass(device, renderPass, nullptr);
 			renderPass = VK_NULL_HANDLE;
 		}
-
-    if (computePipeline != VK_NULL_HANDLE)
-    {
-      vkDestroyPipeline(device, computePipeline, nullptr);
-      computePipeline = VK_NULL_HANDLE;
-    }
-
-    if (computePipelineLayout != VK_NULL_HANDLE)
-    {
-      vkDestroyPipelineLayout(device, computePipelineLayout, nullptr);
-      computePipelineLayout = VK_NULL_HANDLE;
-    }
 	}
 
 	std::vector<char> VulkanPipelineManager::ReadFile(const std::string& filename)
@@ -286,41 +274,6 @@ namespace Engine
 
     vkDestroyShaderModule(device, vertModule, nullptr);
     vkDestroyShaderModule(device, fragModule, nullptr);
-  }
-
-  void VulkanPipelineManager::CreateComputePipeline(const std::string& computeShaderPath, VkDescriptorSetLayout descriptorLayout)
-  {
-    auto code = ReadFile(computeShaderPath);
-    VkShaderModule computeShader = CreateShaderModule(code);
-
-    VkPipelineShaderStageCreateInfo stageInfo{};
-    stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = computeShader;
-    stageInfo.pName = "main";
-
-    // Pipeline layout using compute descriptor set
-    VkPipelineLayoutCreateInfo layoutInfo{};
-    layoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-    layoutInfo.setLayoutCount = 1;
-    layoutInfo.pSetLayouts = &descriptorLayout;
-
-    if (vkCreatePipelineLayout(device, &layoutInfo, nullptr, &computePipelineLayout) != VK_SUCCESS) 
-    {
-      throw std::runtime_error("Failed to create compute pipeline layout!");
-    }
-
-    VkComputePipelineCreateInfo pipelineInfo{};
-    pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-    pipelineInfo.stage = stageInfo;
-    pipelineInfo.layout = computePipelineLayout;
-
-    if (vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &computePipeline) != VK_SUCCESS) 
-    {
-      throw std::runtime_error("Failed to create compute pipeline!");
-    }
-
-    vkDestroyShaderModule(device, computeShader, nullptr);
   }
 
 }

--- a/Source/Engine/Systems/Renderer/Vulkan/VulkanPipelineManager.h
+++ b/Source/Engine/Systems/Renderer/Vulkan/VulkanPipelineManager.h
@@ -27,14 +27,9 @@ namespace Engine
 			uint32_t pushConstantSize
 		);
 
-		void CreateComputePipeline(const std::string& computeShaderPath, VkDescriptorSetLayout descriptorLayout);
-
 		VkRenderPass GetRenderPass() const { return renderPass; }
 		VkPipelineLayout GetPipelineLayout() const { return pipelineLayout; }
 		VkPipeline GetGraphicsPipeline() const { return graphicsPipeline; }
-
-		VkPipeline GetComputePipeline() const { return computePipeline; }
-		VkPipelineLayout GetComputePipelineLayout() const { return computePipelineLayout; }
 
 		void Cleanup();
 
@@ -48,9 +43,6 @@ namespace Engine
 		VkRenderPass renderPass = VK_NULL_HANDLE;
 		VkPipeline graphicsPipeline = VK_NULL_HANDLE;
 		VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
-
-		VkPipeline computePipeline = VK_NULL_HANDLE;
-		VkPipelineLayout computePipelineLayout = VK_NULL_HANDLE;
 
 	};
 

--- a/Source/Engine/Systems/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/Source/Engine/Systems/Renderer/Vulkan/VulkanRenderer.cpp
@@ -108,6 +108,12 @@ namespace Engine
 		);
 		indexDraw->CreateIndirectBuffers(MAX_EXPECTED_INSTANCES, MAX_FRAMES_IN_FLIGHT);
 
+		// We have a huge buffer on the GPU now to store all of our meshes so we never have to change vertice and indice bindings
+		constexpr VkDeviceSize initialVertexSize = 16 * 1024 * 1024; // 16 MB
+		constexpr VkDeviceSize initialIndexSize = 4 * 1024 * 1024;  // 4 MB
+
+		indexDraw->CreateMegaMeshBuffers(initialVertexSize, initialIndexSize);
+
 		// Configure culled rendering mode
 		// Debug mode CPU culling: 100 FPS 
 		// Release mode CPU culling: 2500+ FPS
@@ -481,6 +487,25 @@ namespace Engine
 
 		auto graphicsQueue = deviceManager->GetGraphicsQueue();
 
+		commandManager->EndSingleTimeCommands(commandBuffer, graphicsQueue);
+	}
+
+	void VulkanRenderer::CopyBuffer(
+		VkBuffer srcBuffer,
+		VkBuffer dstBuffer,
+		VkDeviceSize size,
+		VkDeviceSize dstOffset
+	) const
+	{
+		VkCommandBuffer commandBuffer = commandManager->BeginSingleTimeCommands();
+
+		VkBufferCopy copyRegion{};
+		copyRegion.srcOffset = 0;
+		copyRegion.dstOffset = dstOffset;
+		copyRegion.size = size;
+		vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, 1, &copyRegion);
+
+		auto graphicsQueue = deviceManager->GetGraphicsQueue();
 		commandManager->EndSingleTimeCommands(commandBuffer, graphicsQueue);
 	}
 

--- a/Source/Engine/Systems/Renderer/Vulkan/VulkanRenderer.h
+++ b/Source/Engine/Systems/Renderer/Vulkan/VulkanRenderer.h
@@ -45,6 +45,7 @@ namespace Engine
 
 		const std::unique_ptr<VulkanDescriptorManager>& GetDescriptorManager() const { return descriptorManager; }
 		const VkSampler& GetDefaultSampler() const { return defaultSampler; }
+		const std::unique_ptr<VulkanIndexDraw>& GetIndexDraw() const { return indexDraw; }
 
 		// Needs to be called when the window changes size
 		void SetSurfaceSize(uint32_t newWidth, uint32_t newHeight);
@@ -69,6 +70,14 @@ namespace Engine
 			VkBuffer srcBuffer,
 			VkBuffer dstBuffer,
 			VkDeviceSize size
+		) const;
+
+		// Copies data from one buffer to another with an offset
+		void CopyBuffer(
+			VkBuffer srcBuffer,
+			VkBuffer dstBuffer,
+			VkDeviceSize size,
+			VkDeviceSize dstOffset
 		) const;
 
 		// Creates a 2D image on the GPU


### PR DESCRIPTION
The renderer is now much more gpu driven and is properly using a single draw call for the whole scene with as minimal rebinding as possible each frame. This is achieved with a single mega mesh buffer we store all meshes into. We can auto grow and resize it as needed automatically when we register our meshes. We also removed a lot of the compute shader pipeline, which we might add back later as we will need compute shaders running eventually for some stuff. 